### PR TITLE
[release-20.0] Bump to `v20.0.1-SNAPSHOT` after the `v20.0.0` release

### DIFF
--- a/go/vt/servenv/version.go
+++ b/go/vt/servenv/version.go
@@ -19,4 +19,4 @@ package servenv
 // DO NOT EDIT
 // THIS FILE IS AUTO-GENERATED DURING NEW RELEASES BY THE VITESS-RELEASER
 
-const versionName = "20.0.0-SNAPSHOT"
+const versionName = "20.0.1-SNAPSHOT"

--- a/java/client/pom.xml
+++ b/java/client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vitess</groupId>
     <artifactId>vitess-parent</artifactId>
-    <version>20.0.0-SNAPSHOT</version>
+    <version>20.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>vitess-client</artifactId>
 

--- a/java/example/pom.xml
+++ b/java/example/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vitess</groupId>
     <artifactId>vitess-parent</artifactId>
-    <version>20.0.0-SNAPSHOT</version>
+    <version>20.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>vitess-example</artifactId>
 

--- a/java/grpc-client/pom.xml
+++ b/java/grpc-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vitess</groupId>
     <artifactId>vitess-parent</artifactId>
-    <version>20.0.0-SNAPSHOT</version>
+    <version>20.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>vitess-grpc-client</artifactId>
 

--- a/java/jdbc/pom.xml
+++ b/java/jdbc/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.vitess</groupId>
     <artifactId>vitess-parent</artifactId>
-    <version>20.0.0-SNAPSHOT</version>
+    <version>20.0.1-SNAPSHOT</version>
   </parent>
   <artifactId>vitess-jdbc</artifactId>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>io.vitess</groupId>
   <artifactId>vitess-parent</artifactId>
-  <version>20.0.0-SNAPSHOT</version>
+  <version>20.0.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Vitess Java Client libraries [Parent]</name>


### PR DESCRIPTION
Includes the changes required to go back into dev mode (v20.0.1-SNAPSHOT) after the release of v20.0.0.